### PR TITLE
Invalid test from cheatsheet

### DIFF
--- a/tests/lib/model_test.rb
+++ b/tests/lib/model_test.rb
@@ -41,6 +41,23 @@ describe 'Methods related to models' do
     end
   end
 
+  describe 'cheatsheet actions' do
+    before do
+      load_i18n({
+        actions: {
+          create: {
+            base: 'The %{r} has been created'
+          }
+        },
+        models: { admin: { user: { one: "Admin", other: "Admins" } } }
+      })
+    end
+
+    it 'returns a valid create message' do
+      assert_equal @tt.a(:create), 'The admin has been created'
+    end
+  end
+
   describe 'attributes' do
     before do
       load_i18n(attributes: {


### PR DESCRIPTION
Hello,

I've noticed you probably change an API or whatever, the point is your example from cheatsheet for actions won't work... It's because t_t looks for those keys:

`["activerecord.actions.admin.user.create", [:"actions.admin.user.create", :"activerecord.actions.base.create", :"actions.base.create"]]`

but never for `"actions.create.base"` key...
